### PR TITLE
修复临时关闭布局的用法，导致返回template对象的问题；

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+/vendor
+/composer.lock

--- a/src/Think.php
+++ b/src/Think.php
@@ -252,6 +252,19 @@ class Think
         return $this->template->getConfig($name);
     }
 
+    /**
+     * 设置布局
+     * @access public
+     * @param bool|string $name    布局模板名称 false 则关闭布局
+     * @param string      $replace 布局模板内容替换标识
+     * @return $this
+     */
+    public function layout(bool|string $name, string $replace = '') 
+    {
+        $this->template->layout($name, $replace);
+        return $this;
+    }
+
     public function __call($method, $params)
     {
         return call_user_func_array([$this->template, $method], $params);


### PR DESCRIPTION
如改问题描述：
https://github.com/top-think/think-template/issues/25


使用链式调用方法，通过layout方法设置布局时，从view的魔术方法调用template的layout方法，但此时返回的$this是template类，而不是view类，这将导致后续联系调用对象错误。

本次提交意为修复该错误。